### PR TITLE
Task - Wrong currentParticipants when createing new

### DIFF
--- a/Business/Services/SessionService.cs
+++ b/Business/Services/SessionService.cs
@@ -77,6 +77,7 @@ public class SessionService(ISessionRepository sessionRepository) : ISessionServ
         try
         {
             var sessionEntity = SessionFactory.ToEntity(form);
+            sessionEntity.CurrentParticipants = form.MaxParticipants;
             var result = await _sessionRepository.CreateAsync(sessionEntity);
 
             if (result == null)


### PR DESCRIPTION
Updated create method in sessionsService to set CurrentParticipants to the value of maxParticipants when creating new session.